### PR TITLE
Collect traceback if an error occurs in a callback

### DIFF
--- a/src/event_callback.c
+++ b/src/event_callback.c
@@ -41,7 +41,7 @@ is used, no need to manually de-allocate */
 void luaevent_callback(int fd, short event, void* p) {
 	le_callback* cb = p;
 	lua_State* L;
-	int ret;
+	int ret, errfunc;
 	struct timeval new_tv = { 0, 0 };
 	le_base* base;
 	assert(cb);
@@ -49,11 +49,25 @@ void luaevent_callback(int fd, short event, void* p) {
 		return; /* Event has already been collected + destroyed */
 	assert(cb->base->loop_L);
 	L = cb->base->loop_L;
+
+	errfunc = 0;
+
+	lua_getglobal(L, "debug");
+
+	if(lua_istable(L, -1)) {
+		lua_getfield(L, -1, "traceback");
+
+		if(lua_isfunction(L, -1)) {
+			errfunc = lua_gettop(L);
+		}
+	}
+
 	lua_rawgeti(L, LUA_REGISTRYINDEX, cb->callbackRef);
 	lua_pushinteger(L, event);
 	/* cb->base may be NULL after the pcall, if the event is destroyed */
 	base = cb->base;
-	if(lua_pcall(L, 1, 2, 0))
+
+	if(lua_pcall(L, 1, 2, errfunc))
 	{
 		base->errorMessage = luaL_ref(L, LUA_REGISTRYINDEX);
 		event_base_loopbreak(base->base);


### PR DESCRIPTION
We have received a number of bug reports where the tracebacks basically just point at the `base:loop()`, which doesn't really tell you that much. This is an initial attempt at improving this. It would probably be better if one could pick the error handler function instead of it being hardcoded to `debug.traceback`.