### PR TITLE
event_callback.c: Fix to allow 0 timeout values

### DIFF
--- a/src/event_callback.c
+++ b/src/event_callback.c
@@ -70,7 +70,7 @@ void luaevent_callback(int fd, short event, void* p) {
 	memcpy(&new_tv, &cb->timeout, sizeof(new_tv));
 	if(lua_isnumber(L, -1)) {
 		double newTimeout = lua_tonumber(L, -1);
-		if(newTimeout > 0) {
+		if(newTimeout >= 0) {
 			load_timeval(newTimeout, &new_tv);
 		}
 	}


### PR DESCRIPTION
Since commit 4ad6778dc1a9f03e18b5ec0d369c545c09390ab2 it became
impossible to set a timeout of 0, as the default value of 'new_tv'
effectively changed from '0' to 'last used timeout'.

This small fix restores the ability to have 0 timeouts by not
skipping loading the timeout into the new_tv struct when the
returned timeout is 0. The ability to easily re-use the old value
is still possible by returning a negative number such as -1.