### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ language: python
 
 sudo: false
 
+os: linux
+
+arch:
+ - amd64
+ - ppc64le
+
 addons:
     apt:
         packages:
             - libevent-dev
-
 env:
     global:
         - LUAROCKS=3.3
@@ -19,6 +24,12 @@ env:
         - LUA="lua 5.3"
         - LUA="lua 5.2"
         - LUA="lua 5.1"
+jobs:
+    exclude:
+        - arch: ppc64le
+          env: LUA="luajit 2.1"
+        - arch: ppc64le
+          env: LUA="luajit 2.0" 
 
 before_install:
     - pip install hererocks


### PR DESCRIPTION
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
Added ppc64le arch and excluded luajit 2.1 and luajit 2.0 for Travis build.