### PR TITLE
Ease packaging work by allowing downstream adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ INSTALL_PROGRAM = $(INSTALL)
 INSTALL_DATA = $(INSTALL) -m 644
 
 # Flags
-CFLAGS = -Wall -fpic
-LDFLAGS = -shared
+CFLAGS ?= -Wall -fpic
+LDFLAGS ?= -shared
 
 # Directories
 LUA_INC_DIR ?= /usr/include/lua5.1
@@ -21,8 +21,8 @@ INSTALL_DIR_BIN ?= /usr/lib/lua/5.1
 LIB = core.so
 
 all:
-	$(CC) $(CFLAGS) -c -Iinclude -I$(LUA_INC_DIR) src/*.c
-	$(CC) $(LDFLAGS) -o $(LIB) *.o -levent
+	$(CC) $(CFLAGS) $(RPM_OPT_FLAGS) -c -Iinclude -I$(LUA_INC_DIR) src/*.c
+	$(CC) $(LDFLAGS) $(RPM_LD_FLAGS) -o $(LIB) *.o -levent
 
 dist dist-all: distdir dist-bzip2 dist-gzip dist-zip
 
@@ -37,7 +37,7 @@ dist-gzip: distdir
 dist-zip: distdir
 	git archive --format=zip --prefix=$(VERSION)/ HEAD > $(DIST_DIR)/$(VERSION).zip
 
-install: all
+install:
 	mkdir -p $(DESTDIR)$(INSTALL_DIR_LUA)
 	$(INSTALL_DATA) lua/luaevent.lua $(DESTDIR)$(INSTALL_DIR_LUA)/luaevent.lua
 	mkdir -p $(DESTDIR)$(INSTALL_DIR_BIN)/luaevent/


### PR DESCRIPTION
Allow `$CFLAGS` and `$LDFLAGS` adjustments, honor `$RPM_OPT_FLAGS` and `$RPM_LD_FLAGS` (if set) and do not run `make` while running `make install` (#11).